### PR TITLE
Sketches page, add responsive styles

### DIFF
--- a/src/pages/sketches.astro
+++ b/src/pages/sketches.astro
@@ -11,11 +11,15 @@ const sketches = routes.filter(
 ---
 
 <SketchListerPage>
-  <section class='lg:h-full'>
-    <div class='flex lg:h-full max-lg:flex-col'>
-      <div class='m-8 flex flex-col'>
-        <h2 class='mb-4'>sketches</h2>
-        <ul id='sketch-lister' class='space-y-2 flex-1'>
+  <section class='h-full'>
+    <div class='h-full flex flex-col md:flex-row'>
+      <div class='p-4 flex flex-col md:py-8'>
+        <div class='flex justify-between items-start px-2 md:flex-col'>
+          <a href='/' class='mb-4 hidden md:block'>Back</a>
+          <h2 class='mb-4'>sketches</h2>
+          <a href='/' class="md:hidden">Back</a>
+        </div>
+        <ul id='sketch-lister' class='space-y-2 max-h-30 overflow-y-scroll md:flex-1 md:max-h-full'>
           {
             sketches.map((sketch) => (
               <li>
@@ -26,13 +30,12 @@ const sketches = routes.filter(
             ))
           }
         </ul>
-        <a href="/" class="lg:mb-4 mt-4 max-w-max">Back</a>
       </div>
-      <div class='m-8 flex-1 shadow-2xl rounded-2xl flex flex-col'>
+      <div class='m-2 flex-1 shadow-2xl rounded-2xl flex flex-col md:m-8'>
         <iframe
           id='sketch-viewport'
           src='/_example/loading'
-          class='flex-1 rounded-t-2xl max-lg:min-h-svw'></iframe>
+          class='flex-1 rounded-t-2xl'></iframe>
         <div class='p-4 border-t-3 border-neutral-400 border-dashed'>
           <p id='sketch-title'>...</p>
           <p id='sketch-description'>...</p>

--- a/src/pages/sketches.astro
+++ b/src/pages/sketches.astro
@@ -3,6 +3,7 @@ import SketchListerPage from '../layouts/SketchListerPage.astro';
 import { DOMAIN } from '../constants.js';
 import { getMemberPagesRoutes } from '../utils/index.js';
 const routes = getMemberPagesRoutes();
+
 const sketches = routes.filter(
   (p) =>
     p.props.metadata.tags?.includes('sketch') && p.params.alias !== '_example'
@@ -10,9 +11,9 @@ const sketches = routes.filter(
 ---
 
 <SketchListerPage>
-  <section class='h-full'>
-    <div class='flex h-full'>
-      <div class='px-4 py-8 flex flex-col'>
+  <section class='lg:h-full'>
+    <div class='flex lg:h-full max-lg:flex-col'>
+      <div class='m-8 flex flex-col'>
         <h2 class='mb-4'>sketches</h2>
         <ul id='sketch-lister' class='space-y-2 flex-1'>
           {
@@ -25,13 +26,13 @@ const sketches = routes.filter(
             ))
           }
         </ul>
-        <a href="/" class="mb-4">Back</a>
+        <a href="/" class="lg:mb-4 mt-4 max-w-max">Back</a>
       </div>
       <div class='m-8 flex-1 shadow-2xl rounded-2xl flex flex-col'>
         <iframe
           id='sketch-viewport'
           src='/_example/loading'
-          class='flex-1 rounded-t-2xl'></iframe>
+          class='flex-1 rounded-t-2xl max-lg:min-h-svw'></iframe>
         <div class='p-4 border-t-3 border-neutral-400 border-dashed'>
           <p id='sketch-title'>...</p>
           <p id='sketch-description'>...</p>

--- a/src/styles/sketch-lister.css
+++ b/src/styles/sketch-lister.css
@@ -6,9 +6,14 @@
     margin: 0;
     padding: 0;
     width: 100%;
-    height: 100%;
-    overflow: hidden;
-    overscroll-behavior: none;
+  }
+  @media min-width(1024px) {
+    html,
+    body {
+      height: 100%;
+      overflow: hidden;
+      overscroll-behavior: none;
+    }
   }
 
   button {

--- a/src/styles/sketch-lister.css
+++ b/src/styles/sketch-lister.css
@@ -6,14 +6,9 @@
     margin: 0;
     padding: 0;
     width: 100%;
-  }
-  @media min-width(1024px) {
-    html,
-    body {
-      height: 100%;
-      overflow: hidden;
-      overscroll-behavior: none;
-    }
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;  
   }
 
   button {


### PR DESCRIPTION
Super quick solution for the Sketches page on small screens. 
I think we will need to make a design decision, in regards on how to list the sketches when they will grow in number. 
For example, we could have the sketch first, and the long list stacked underneath, or we could have a off-canvas menu listing the sketches...