### PR TITLE
Update IS_PROD constant to directly reference import.meta.env.PROD

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-const IS_PROD = import.meta?.env?.PROD ?? false
+const IS_PROD = import.meta.env.PROD;
 
 export const REPO_PATH = 'sb-luis/creative-coding-bookclub'
 export const DOMAIN = IS_PROD ? 'https://creativecodingbook.club' : 'http://localhost:4321'


### PR DESCRIPTION
Although the build runs with success, I'm getting in a "Dynamic access of "import.meta.env" is not supported" error, while running the app in development mode. 
Not sure why the optional chaining was needed thou, so I'd wait for Louis to come back, or someone else to test the current main branch locally and see if they have the same issue.